### PR TITLE
Bump _XOPEN_SOURCE to 700 for strndup()

### DIFF
--- a/src/libybinlogp.c
+++ b/src/libybinlogp.c
@@ -13,7 +13,7 @@
  * Functions starting with ybpi_ are internal-only and should be static
  */
 
-#define _XOPEN_SOURCE 600
+#define _XOPEN_SOURCE 700
 #define _GNU_SOURCE
 
 #include <stdio.h>


### PR DESCRIPTION
The strndup() function wasn't added until [X/Open 7, incorporating POSIX 2008.](http://pubs.opengroup.org/onlinepubs/9699919799/functions/strndup.html)  So we have to bump _XOPEN_SOURCE from 600 to 700.
